### PR TITLE
fixups for compute and storage tests

### DIFF
--- a/compute/compute.go
+++ b/compute/compute.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"log"
+	"os"
 
 	"github.com/Azure-Samples/azure-sdk-for-go-samples/helpers"
 	"github.com/Azure-Samples/azure-sdk-for-go-samples/iam"
@@ -30,9 +31,14 @@ func getVMClient() (compute.VirtualMachinesClient, error) {
 // Username, password, and sshPublicKeyPath determine logon credentials.
 func CreateVM(vmName, nicName, username, password, sshPublicKeyPath string) (<-chan compute.VirtualMachine, <-chan error) {
 	nic, _ := network.GetNic(nicName)
-	sshBytes, err := ioutil.ReadFile(sshPublicKeyPath)
-	if err != nil {
-		log.Fatalf("failed to read SSH key data: %v", err)
+
+	var sshBytes []byte
+	var err error
+	if _, err = os.Stat(sshPublicKeyPath); err == nil {
+		sshBytes, err = ioutil.ReadFile(sshPublicKeyPath)
+		if err != nil {
+			log.Fatalf("failed to read SSH key data: %v", err)
+		}
 	}
 
 	vmClient, _ := getVMClient()

--- a/storage/storage_test.go
+++ b/storage/storage_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 var (
-	accountName   = "azure-samples-go-" + helpers.GetRandomLetterSequence(10)
+	accountName   = "azuresamplesgo" + helpers.GetRandomLetterSequence(10)
 	containerName = "container1"
 	blobName      = "blob1"
 )


### PR DESCRIPTION
addresses a couple issues:

* better handling when a local SSH key isn't available (e.g. in Jenkins)
* remove dashes from default storage account name