### PR TITLE
switch fake SSH key to RSA

### DIFF
--- a/compute/compute.go
+++ b/compute/compute.go
@@ -20,7 +20,8 @@ const (
 	sku       = "16.04.0-LTS"
 )
 
-var fakepubkey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIM97OXV9dTCZdZJkSk+W2r9XqmlbuGkZU1b1zyiAaXZq azureuser"
+// fakepubkey is used if a key isn't available at the specified path in CreateVM(...)
+var fakepubkey = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC7laRyN4B3YZmVrDEZLZoIuUA72pQ0DpGuZBZWykCofIfCPrFZAJgFvonKGgKJl6FGKIunkZL9Us/mV4ZPkZhBlE7uX83AAf5i9Q8FmKpotzmaxN10/1mcnEE7pFvLoSkwqrQSkrrgSm8zaJ3g91giXSbtqvSIj/vk2f05stYmLfhAwNo3Oh27ugCakCoVeuCrZkvHMaJgcYrIGCuFo6q0Pfk9rsZyriIqEa9AtiUOtViInVYdby7y71wcbl0AbbCZsTSqnSoVxm2tRkOsXV6+8X4SnwcmZbao3H+zfO1GBhQOLxJ4NQbzAa8IJh810rYARNLptgmsd4cYXVOSosTX azureuser"
 
 func getVMClient() (compute.VirtualMachinesClient, error) {
 	token, _ := iam.GetResourceManagementToken(iam.OAuthGrantTypeServicePrincipal)


### PR DESCRIPTION
because ed25519 (ECDSA) isn't supported in Azure, see https://support.microsoft.com/en-us/help/4013792/can-t-use-ed25519-ssh-keys-for-azure-linux-vms