### PR TITLE
replace build and test system

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,27 +1,12 @@
 sudo: required
 language: go
-services:
-- docker
 go:
 - master
 - 1.10.x
 - 1.9.x
-install:
-- go get -u github.com/golang/lint/golint
-- go get -u github.com/golang/dep/cmd/dep
 script:
-- dirs=$(go list ./...)
-- test -z "$(gofmt -s -l -w $(find ./* -type d -print) | tee /dev/stderr)"
-- test -z "`for d in $dirs; do golint $d | tee /dev/stderr; done`"
-- test -z "$(go vet ./... |  grep -v 'refers to unknown identifier' | tee /dev/stderr)"
-- dep ensure
-- bash tools/build.sh
-- bash tools/build_on_travis.sh
-env:
-  global:
-  - secure: dkNK8NZ42OIqwBoiCiZFECt6Rq/iVPWOzPlNDJPlfpEyiC5SSGockXCVHmmpQxsKmnk1t7FKg56rMEw5SCMB2GQZ2QSuoQHqPASals1oOQIXnmEpXzVKVSR1a6igGqXirV4Ofje4rLR4I9+QpJObJIeI82Rur3Rtq1uwTE7jxxfv7NnH760BXV1+OhA+BECozjTf+4bel1wW7INsVzOhJ5NK3j4CfdyetaigER/pwb2T/b1yWXEHEKExva9/+hUNh0MZl5Y2SE1II5ElKzXswQPPlLbwuG30L2x2IyxNrOoaYa5ZFgPXb/BY4nu+xFUXktbcP0E9Njb3a38jMCyqgq4LiOi8qV+zAreDpyWmJoL75ScEFqI578pYbWUVPfBrhJAbYkPF/wNEmUVuJaft9bz4UG70koOTimbUZdTGKXyxNHG5cWWAuVBoho2VtMYy72m3C/g6KcU2v/+PKBnCJY/QBSqoK/IHWEh2zt+hcCWT0byu8f3pNodkm/bMZ336yRMj+2O9cK5ao8rogOL6aof3XTuZWnp+zDAmFx94IAeaPW/tavIPjunyII4sQcAtI4zOljtPDgnNkpWnGrkdV5fFULJZvmw0EjWn5JnMCh6XYsi9+4iJ7XWJKXtS46c7ilGdy1U3N1kGta9iroZtHa+ZhJkFUx1EfAA/RXeTgW8=
-  - secure: q92ZNT8eBxgOP03u8a9U7HXNJpWWpk1g//THQpuDGN+Fjzy0D++yawov6/6ekwIAHLZApIQ28ItsMn3HZREbzzSW9PrpgrjDPWjlYnYT8H8MbwJUBtMkdw29iNxsdwAt1k311GDCVb82FIj2HWPVaXbrVHNabBSDlf1OtifMf+4lQdi3lZHw1oGamGgNXlWtyxa19SLzrPKzDqtT2BabPk/2M/gSvVhuvqjMKKxIssQtP0uQybyi0cXBjCjJqND9zMeI2SCw+3YUHoQijSrJ1Xk/pug/OW2rlDasIN+7NiH3CvFLOzMAyDnLdYLgdCjpLbLaGeTKEP4oxkFXcfVMNOt2FiFmLKR775O+GU1IQNxU9glseB2Eez9SLCATnTACCDeAe7x0UCRv/byNXWz3BSOB1J8qZl0B15Ct8sNhAddUYon5pjKAhTI6nad9IAYhXW9bLRt2H1Dgu5ms/DeJtlKtXK6jVjxUW08XaspEmwpmpiCzmh1yCzukZeN59nldvjajr+AeQtx6yY2aE1aOan9Ydu8YRDE6qCNZpYrnDXOjRS+bBqNryMVt3LnQIb2k9RBOtYZ2JOaZ+aBAcg+zanWDUfhROLtdRn79S8o0bLSUWcoP65YCx0+cDeoPLuZJ0UOPlsF+sThDWXj5e9PcPRwa5mQPbZQ8JYm+mnlo1L8=
+- make test_pr
 matrix:
   allow_failures:
   - go: master
-  
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,4 +9,3 @@ script:
 matrix:
   allow_failures:
   - go: master
-

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,18 +2,24 @@
 
 
 [[projects]]
+  digest = "1:ea614d90af24cec00cde502e174e3b827627f44c5d0ffc479c0bff9f0545adb6"
   name = "cloud.google.com/go"
   packages = ["civil"]
-  revision = "0fd7230b2a7505833d5f69b75cbd6c9582401479"
-  version = "v0.23.0"
+  pruneopts = ""
+  revision = "777200caa7fb8936aed0f12b1fd79af64cc83ec9"
+  version = "v0.24.0"
 
 [[projects]]
+  digest = "1:6f302284bb48712a01cdcd3216e8bbb293d1edb618f55b5fe7f92521cce930c7"
   name = "github.com/Azure/azure-pipeline-go"
   packages = ["pipeline"]
+  pruneopts = ""
   revision = "7571e8eb0876932ab505918ff7ed5107773e5ee2"
   version = "0.1.7"
 
 [[projects]]
+  branch = "master"
+  digest = "1:b2f5901d9c20702b2d9c2e538e6cfb459f0461b92b42f8ad798583d345cab569"
   name = "github.com/Azure/azure-sdk-for-go"
   packages = [
     "profiles/2017-03-09/compute/mgmt/compute",
@@ -49,18 +55,21 @@
     "services/storage/mgmt/2016-01-01/storage",
     "services/storage/mgmt/2017-06-01/storage",
     "services/web/mgmt/2016-09-01/web",
-    "version"
+    "version",
   ]
-  revision = "7971189ecf5a584b9211f2527737f94bb979644e"
-  version = "v17.4.0"
+  pruneopts = ""
+  revision = "fbe7db0e3f9793ba3e5704efbab84f51436c136e"
 
 [[projects]]
+  branch = "master"
+  digest = "1:f8655dbafc1a23dd373a81ebe0283d50d0cb6f0cc96723f007a57c88a9f73fe9"
   name = "github.com/Azure/azure-storage-blob-go"
   packages = ["2016-05-31/azblob"]
-  revision = "66ba96e49ebbdc3cd26970c6c675c906d304b5e2"
-  version = "0.1.4"
+  pruneopts = ""
+  revision = "eaae161d9d5e07363f04ddb19d84d57efc66d1a1"
 
 [[projects]]
+  digest = "1:24a65c080381654718032ec9cf23e6fbdb7d49dcdbd20de38428dc46480abff7"
   name = "github.com/Azure/go-autorest"
   packages = [
     "autorest",
@@ -70,81 +79,144 @@
     "autorest/date",
     "autorest/to",
     "autorest/utils",
-    "autorest/validation"
+    "autorest/validation",
   ]
-  revision = "f04d503958a4fe854c1b41667c73f8813c9dd9c3"
-  version = "v10.11.2"
+  pruneopts = ""
+  revision = "1f7cd6cfe0adea687ad44a512dfe76140f804318"
+  version = "v10.12.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:e3d38fd9948d998cc8c5aae252d48ed9d74d5326489cacbfbf7bd5302ca86ec6"
   name = "github.com/denisenkom/go-mssqldb"
   packages = [
     ".",
-    "internal/cp"
+    "internal/cp",
   ]
-  revision = "95cbf6513ab5f7a79e04b2baba760acdd3b45dd5"
+  pruneopts = ""
+  revision = "242fa5aa1b45aeb9fcdfeee88822982e3f548e22"
 
 [[projects]]
+  digest = "1:2426da75f49e5b8507a6ed5d4c49b06b2ff795f4aec401c106b7db8fb2625cd7"
   name = "github.com/dgrijalva/jwt-go"
   packages = ["."]
+  pruneopts = ""
   revision = "06ea1031745cb8b3dab3f6a236daf2b0aa468b7e"
   version = "v3.2.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:654ac9799e7a8a586d8690bb2229a4f3408bbfe2c5494bf4dfe043053eeb5496"
   name = "github.com/dimchansky/utfbom"
   packages = ["."]
+  pruneopts = ""
   revision = "6c6132ff69f0f6c088739067407b5d32c52e1d0f"
 
 [[projects]]
   branch = "master"
+  digest = "1:0d1bc2d8df6654687f7e2dafb6ecaea40adeb6e93c92a35ebb2cc1e2fa6ac438"
   name = "github.com/globalsign/mgo"
   packages = [
     ".",
     "bson",
     "internal/json",
     "internal/sasl",
-    "internal/scram"
+    "internal/scram",
   ]
-  revision = "efe0945164a7e582241f37ae8983c075f8f2e870"
+  pruneopts = ""
+  revision = "113d3961e7311526535a1ef7042196563d442761"
 
 [[projects]]
+  digest = "1:a0cb5f41e61664683912f073ec14760a9f60b432d75afa01f64e1db5443a5539"
   name = "github.com/marstr/collection"
   packages = ["."]
+  pruneopts = ""
   revision = "871b1cfa2ab97d3d8f54a034280907896190c346"
   version = "v0.3.3"
 
 [[projects]]
   branch = "master"
+  digest = "1:72da3dc7eddc1f4695da12df937debc7dcf027b1c0f57ec415fdad097cef7c43"
   name = "github.com/marstr/randname"
   packages = ["."]
+  pruneopts = ""
   revision = "48a63b6052f1f9373db9388a658da30c6ab53db1"
 
 [[projects]]
+  digest = "1:7f569d906bdd20d906b606415b7d794f798f91a62fcfb6a4daa6d50690fb7a3f"
   name = "github.com/satori/go.uuid"
   packages = ["."]
+  pruneopts = ""
   revision = "f58768cc1a7a7e77a3bd49e98cdd21419399b6a3"
   version = "v1.2.0"
 
 [[projects]]
+  digest = "1:f65da16eb7982a274ab8ecbe726eb044a58078b65447a6688141e1950ed4de56"
   name = "github.com/subosito/gotenv"
   packages = ["."]
+  pruneopts = ""
   revision = "69b5b6104433beb2cb9c3ce00bdadf3c7c2d3f34"
   version = "v1.1.1"
 
 [[projects]]
   branch = "master"
+  digest = "1:e79c3d6b195477b429f017aaa02af135249bbdff31c9acbd8a93bb37a4ef7d3b"
   name = "golang.org/x/crypto"
   packages = [
     "md4",
     "pkcs12",
-    "pkcs12/internal/rc2"
+    "pkcs12/internal/rc2",
   ]
-  revision = "8ac0e0d97ce45cd83d1d7243c060cb8461dda5e9"
+  pruneopts = ""
+  revision = "a49355c7e3f8fe157a85be2f77e6e269a0f89602"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "dfd423ef2de12050b11b49b5311cbbfbed101b81c5a233349ab9f5ae30ccf90b"
+  input-imports = [
+    "github.com/Azure/azure-sdk-for-go/profiles/2017-03-09/compute/mgmt/compute",
+    "github.com/Azure/azure-sdk-for-go/profiles/2017-03-09/network/mgmt/network",
+    "github.com/Azure/azure-sdk-for-go/profiles/2017-03-09/resources/mgmt/resources",
+    "github.com/Azure/azure-sdk-for-go/profiles/2017-03-09/storage/mgmt/storage",
+    "github.com/Azure/azure-sdk-for-go/services/authorization/mgmt/2015-07-01/authorization",
+    "github.com/Azure/azure-sdk-for-go/services/batch/2017-09-01.6.0/batch",
+    "github.com/Azure/azure-sdk-for-go/services/batch/mgmt/2017-09-01/batch",
+    "github.com/Azure/azure-sdk-for-go/services/cdn/mgmt/2017-10-12/cdn",
+    "github.com/Azure/azure-sdk-for-go/services/cognitiveservices/mgmt/2017-04-18/cognitiveservices",
+    "github.com/Azure/azure-sdk-for-go/services/cognitiveservices/v1.0/customsearch",
+    "github.com/Azure/azure-sdk-for-go/services/cognitiveservices/v1.0/entitysearch",
+    "github.com/Azure/azure-sdk-for-go/services/cognitiveservices/v1.0/imagesearch",
+    "github.com/Azure/azure-sdk-for-go/services/cognitiveservices/v1.0/newssearch",
+    "github.com/Azure/azure-sdk-for-go/services/cognitiveservices/v1.0/spellcheck",
+    "github.com/Azure/azure-sdk-for-go/services/cognitiveservices/v1.0/videosearch",
+    "github.com/Azure/azure-sdk-for-go/services/cognitiveservices/v1.0/websearch",
+    "github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2017-03-30/compute",
+    "github.com/Azure/azure-sdk-for-go/services/containerinstance/mgmt/2017-08-01-preview/containerinstance",
+    "github.com/Azure/azure-sdk-for-go/services/containerservice/mgmt/2017-09-30/containerservice",
+    "github.com/Azure/azure-sdk-for-go/services/cosmos-db/mgmt/2015-04-08/documentdb",
+    "github.com/Azure/azure-sdk-for-go/services/cosmos-db/mongodb",
+    "github.com/Azure/azure-sdk-for-go/services/graphrbac/1.6/graphrbac",
+    "github.com/Azure/azure-sdk-for-go/services/keyvault/2016-10-01/keyvault",
+    "github.com/Azure/azure-sdk-for-go/services/keyvault/mgmt/2016-10-01/keyvault",
+    "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2017-09-01/network",
+    "github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2017-05-10/resources",
+    "github.com/Azure/azure-sdk-for-go/services/sql/mgmt/2015-05-01-preview/sql",
+    "github.com/Azure/azure-sdk-for-go/services/storage/mgmt/2017-06-01/storage",
+    "github.com/Azure/azure-sdk-for-go/services/web/mgmt/2016-09-01/web",
+    "github.com/Azure/azure-storage-blob-go/2016-05-31/azblob",
+    "github.com/Azure/go-autorest/autorest",
+    "github.com/Azure/go-autorest/autorest/adal",
+    "github.com/Azure/go-autorest/autorest/azure",
+    "github.com/Azure/go-autorest/autorest/azure/auth",
+    "github.com/Azure/go-autorest/autorest/date",
+    "github.com/Azure/go-autorest/autorest/to",
+    "github.com/Azure/go-autorest/autorest/utils",
+    "github.com/denisenkom/go-mssqldb",
+    "github.com/globalsign/mgo",
+    "github.com/globalsign/mgo/bson",
+    "github.com/marstr/randname",
+    "github.com/satori/go.uuid",
+    "github.com/subosito/gotenv",
+  ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -6,9 +6,9 @@
   name = "github.com/Azure/azure-storage-blob-go"
   branch = "master"
 
-[[constraint]]
+[[override]]
   name = "github.com/Azure/go-autorest"
-  branch = "master"
+  version = "^10.12.0"
 
 [[constraint]]
   branch = "master"

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,35 @@
+GO ?= go
+GH_ORG ?= Azure-Samples
+ROOT = github.com/$(GH_ORG)/azure-sdk-for-go-samples
+BASE = $(GOPATH)/src/$(ROOT)
+
+# tested on 1.9+, no need to exclude /vendor
+# to specify packages to skip: `PKGS_SKIP_RE='storage|graphrbac' make ...`
+PKGS_SKIP_RE ?= ''
+PKGS         != $(GO) list ./... | sed 's@$(ROOT)/@./@' | grep -v -E "$(PKGS_SKIP_RE)"
+
+# uses Azure resources
+test: dep
+	$(GO) test -v $(PKGS)
+
+test_pr: lint
+	$(GO) build -v $(PKGS)
+
+dep:
+	$(GO) get -u github.com/golang/dep/cmd/dep
+	cd $(BASE) && dep ensure
+
+lint: dep
+	$(GO) get -v github.com/alecthomas/gometalinter
+	gometalinter --update
+	# TODO: fix problems and enable all tests
+	# TODO: address warnings
+	gometalinter --errors \
+		--enable=gofmt \
+		--enable=goimports \
+		--disable=vet \
+		--disable=gotype \
+		--disable=megacheck \
+		$(PKGS)
+
+.PHONY: test test_pr dep lint

--- a/Makefile
+++ b/Makefile
@@ -8,12 +8,16 @@ BASE = $(GOPATH)/src/$(ROOT)
 PKGS_SKIP_RE ?= ''
 PKGS         != $(GO) list ./... | sed 's@$(ROOT)/@./@' | grep -v -E "$(PKGS_SKIP_RE)"
 
+test_pr: lint build
+
 # uses Azure resources
 test: dep
 	$(GO) test -v $(PKGS)
 
-test_pr: lint
-	$(GO) build -v $(PKGS)
+build: dep
+	# have to relist packages here cause Travis doesn't pick up the global script-based var
+	$(GO) build -v \
+		$(shell $(GO) list ./... | sed 's@$(ROOT)/@./@' | grep -v -E "$(PKGS_SKIP_RE)")
 
 dep:
 	$(GO) get -u github.com/golang/dep/cmd/dep
@@ -21,7 +25,7 @@ dep:
 
 lint: dep
 	$(GO) get -v github.com/alecthomas/gometalinter
-	gometalinter --update
+	gometalinter --install
 	# TODO: fix problems and enable all tests
 	# TODO: address warnings
 	gometalinter --errors \
@@ -32,4 +36,4 @@ lint: dep
 		--disable=megacheck \
 		$(PKGS)
 
-.PHONY: test test_pr dep lint
+.PHONY: test test_pr build dep lint

--- a/mysql/mysql_test.go
+++ b/mysql/mysql_test.go
@@ -1,6 +1,0 @@
-// Copyright (c) Microsoft and contributors.  All rights reserved.
-//
-// This source code is licensed under the MIT license found in the
-// LICENSE file in the root directory of this source tree.
-
-package mysql

--- a/postgresql/postgresql_test.go
+++ b/postgresql/postgresql_test.go
@@ -1,6 +1,0 @@
-// Copyright (c) Microsoft and contributors.  All rights reserved.
-//
-// This source code is licensed under the MIT license found in the
-// LICENSE file in the root directory of this source tree.
-
-package postgresql

--- a/redis/redis_test.go
+++ b/redis/redis_test.go
@@ -1,6 +1,0 @@
-// Copyright (c) Microsoft and contributors.  All rights reserved.
-//
-// This source code is licensed under the MIT license found in the
-// LICENSE file in the root directory of this source tree.
-
-package redis

--- a/servicebus/servicebus_test.go
+++ b/servicebus/servicebus_test.go
@@ -1,6 +1,0 @@
-// Copyright (c) Microsoft and contributors.  All rights reserved.
-//
-// This source code is licensed under the MIT license found in the
-// LICENSE file in the root directory of this source tree.
-
-package servicebus


### PR DESCRIPTION
The build and test system in this repo need to be cleaned up. This PR:

1. adds a `Makefile` to encapsulate future build scripts
1. updates `.travis.yml` to use said Makefile, specifically the `test_pr` target.

The `test_pr` target runs a bunch of linters with gometalinter, then `go build` on all the packages in this repo. It seems a reasonable start :).

The `test` target calls `go test` instead and will be for admin use only since it uses Azure resources; once I have a service principal with appropriate rights I'll finish that.

I didn't touch anything existing so that our internal Jenkins isn't yet effected, but once all is well I hope to remove most or all of the `tools/` dir as it is today. I was hoping to get this merged relatively quickly so PR tests can start passing. PTAL @vladbarosan @devigned @marstr, thanks!