### PR TITLE
Create Active Directory Group Sample

### DIFF
--- a/graphrbac/graph.go
+++ b/graphrbac/graph.go
@@ -34,8 +34,8 @@ func getApplicationsClient() graphrbac.ApplicationsClient {
 func getADGroupsClient() graphrbac.GroupsClient {
 	groupsClient := graphrbac.NewGroupsClient(config.TenantID())
 	a, _ := iam.GetGraphAuthorizer()
-	appClient.Authorizer = a
-	appClient.AddToUserAgent(config.UserAgent())
+	groupsClient.Authorizer = a
+	groupsClient.AddToUserAgent(config.UserAgent())
 	return groupsClient
 }
 

--- a/graphrbac/graph.go
+++ b/graphrbac/graph.go
@@ -105,6 +105,6 @@ func CreateADGroup(ctx context.Context) (graphrbac.ADGroup, error) {
 		DisplayName:             to.StringPtr("Go SDK Samples"),
 		MailEnabled:             to.BoolPtr(true),
 		MailNickname:            to.StringPtr("Go SDK Sample MailNickname"),
-		SecurityEnabled:         to.BoolPtr(true)
+		SecurityEnabled:         to.BoolPtr(true),
 	})
 }

--- a/graphrbac/graph.go
+++ b/graphrbac/graph.go
@@ -102,9 +102,9 @@ func GetCurrentUser(ctx context.Context) (graphrbac.AADObject, error) {
 func CreateADGroup(ctx context.Context) (graphrbac.ADGroup, error) {
 	groupsClient := getADGroupsClient()
 	return groupsClient.Create(ctx, graphrbac.GroupCreateParameters{
-		DisplayName:             to.StringPtr("Go SDK Samples"),
+		DisplayName:             to.StringPtr("GoSDKSamples"),
 		MailEnabled:             to.BoolPtr(true),
-		MailNickname:            to.StringPtr("Go SDK Sample MailNickname"),
+		MailNickname:            to.StringPtr("GoSDKMN"),
 		SecurityEnabled:         to.BoolPtr(true),
 	})
 }

--- a/graphrbac/graph.go
+++ b/graphrbac/graph.go
@@ -31,6 +31,7 @@ func getApplicationsClient() graphrbac.ApplicationsClient {
 	return appClient
 }
 
+// getADGroupsClient retrieves a GroupsClient to assist with creating and managing Active Directory groups
 func getADGroupsClient() graphrbac.GroupsClient {
 	groupsClient := graphrbac.NewGroupsClient(config.TenantID())
 	a, _ := iam.GetGraphAuthorizer()

--- a/graphrbac/graph.go
+++ b/graphrbac/graph.go
@@ -102,9 +102,9 @@ func GetCurrentUser(ctx context.Context) (graphrbac.AADObject, error) {
 func CreateADGroup(ctx context.Context) (graphrbac.ADGroup, error) {
 	groupsClient := getADGroupsClient()
 	return groupsClient.Create(ctx, graphrbac.GroupCreateParameters{
-		DisplayName:             to.StringPtr("GoSDKSamples"),
-		MailEnabled:             to.BoolPtr(true),
-		MailNickname:            to.StringPtr("GoSDKMN"),
-		SecurityEnabled:         to.BoolPtr(true),
+		DisplayName:     to.StringPtr("GoSDKSamples"),
+		MailEnabled:     to.BoolPtr(true),
+		MailNickname:    to.StringPtr("GoSDKMN"),
+		SecurityEnabled: to.BoolPtr(true),
 	})
 }

--- a/graphrbac/graph.go
+++ b/graphrbac/graph.go
@@ -110,7 +110,7 @@ func CreateADGroup(ctx context.Context) (graphrbac.ADGroup, error) {
 	})
 }
 
-// DeleteADGroup deletes an Active Directory group
+// DeleteADGroup deletes the specified Active Directory group
 func DeleteADGroup(ctx context.Context, groupObjID string) (autorest.Response, error) {
 	groupClient := getADGroupsClient()
 	return groupClient.Delete(ctx, groupObjID)

--- a/graphrbac/graph.go
+++ b/graphrbac/graph.go
@@ -103,8 +103,8 @@ func CreateADGroup(ctx context.Context) (graphrbac.ADGroup, error) {
 	groupsClient := getADGroupsClient()
 	return groupsClient.Create(ctx, graphrbac.GroupCreateParameters{
 		DisplayName:             to.StringPtr("Go SDK Samples"),
-		MailEnabled:						 to.BoolPtr(true),
+		MailEnabled:             to.BoolPtr(true),
 		MailNickname:            to.StringPtr("Go SDK Sample MailNickname"),
-		SecurityEnabled:				 to.BoolPtr(true)
+		SecurityEnabled:         to.BoolPtr(true)
 	})
 }

--- a/graphrbac/graph.go
+++ b/graphrbac/graph.go
@@ -31,6 +31,14 @@ func getApplicationsClient() graphrbac.ApplicationsClient {
 	return appClient
 }
 
+func getADGroupsClient() graphrbac.GroupsClient {
+	appClient := graphrbac.NewGroupsClient(config.TenantID())
+	a, _ := iam.GetGraphAuthorizer()
+	appClient.Authorizer = a
+	appClient.AddToUserAgent(config.UserAgent())
+	return groupsClient
+}
+
 // CreateServicePrincipal creates a service principal associated with the specified application.
 func CreateServicePrincipal(ctx context.Context, appID string) (graphrbac.ServicePrincipal, error) {
 	spClient := getServicePrincipalsClient()
@@ -88,4 +96,15 @@ func getObjectsClient() graphrbac.ObjectsClient {
 func GetCurrentUser(ctx context.Context) (graphrbac.AADObject, error) {
 	objClient := getObjectsClient()
 	return objClient.GetCurrentUser(ctx)
+}
+
+// Create Actice Directory group
+func CreateADGroup(ctx context.Context) (graphrbac.ADGroup, error) {
+	groupsClient := getADGroupsClient()
+	return groupsClient.Create(ctx, graphrbac.GroupCreateParameters{
+		DisplayName:             to.StringPtr("Go SDK Samples"),
+		MailEnabled:						 to.BoolPtr(true),
+		MailNickname:            to.StringPtr("Go SDK Sample MailNickname"),
+		SecurityEnabled:				 to.BoolPtr(true)
+	})
 }

--- a/graphrbac/graph.go
+++ b/graphrbac/graph.go
@@ -103,7 +103,7 @@ func CreateADGroup(ctx context.Context) (graphrbac.ADGroup, error) {
 	groupsClient := getADGroupsClient()
 	return groupsClient.Create(ctx, graphrbac.GroupCreateParameters{
 		DisplayName:     to.StringPtr("GoSDKSamples"),
-		MailEnabled:     to.BoolPtr(true),
+		MailEnabled:     to.BoolPtr(false),
 		MailNickname:    to.StringPtr("GoSDKMN"),
 		SecurityEnabled: to.BoolPtr(true),
 	})

--- a/graphrbac/graph.go
+++ b/graphrbac/graph.go
@@ -98,7 +98,7 @@ func GetCurrentUser(ctx context.Context) (graphrbac.AADObject, error) {
 	return objClient.GetCurrentUser(ctx)
 }
 
-// Create Actice Directory group
+// CreateADGroup creates an Active Directory group
 func CreateADGroup(ctx context.Context) (graphrbac.ADGroup, error) {
 	groupsClient := getADGroupsClient()
 	return groupsClient.Create(ctx, graphrbac.GroupCreateParameters{

--- a/graphrbac/graph.go
+++ b/graphrbac/graph.go
@@ -32,7 +32,7 @@ func getApplicationsClient() graphrbac.ApplicationsClient {
 }
 
 func getADGroupsClient() graphrbac.GroupsClient {
-	appClient := graphrbac.NewGroupsClient(config.TenantID())
+	groupsClient := graphrbac.NewGroupsClient(config.TenantID())
 	a, _ := iam.GetGraphAuthorizer()
 	appClient.Authorizer = a
 	appClient.AddToUserAgent(config.UserAgent())

--- a/graphrbac/graph.go
+++ b/graphrbac/graph.go
@@ -101,11 +101,17 @@ func GetCurrentUser(ctx context.Context) (graphrbac.AADObject, error) {
 
 // CreateADGroup creates an Active Directory group
 func CreateADGroup(ctx context.Context) (graphrbac.ADGroup, error) {
-	groupsClient := getADGroupsClient()
-	return groupsClient.Create(ctx, graphrbac.GroupCreateParameters{
+	groupClient := getADGroupsClient()
+	return groupClient.Create(ctx, graphrbac.GroupCreateParameters{
 		DisplayName:     to.StringPtr("GoSDKSamples"),
 		MailEnabled:     to.BoolPtr(false),
 		MailNickname:    to.StringPtr("GoSDKMN"),
 		SecurityEnabled: to.BoolPtr(true),
 	})
+}
+
+// DeleteADGroup deletes an Active Directory group
+func DeleteADGroup(ctx context.Context, groupObjID string) (autorest.Response, error) {
+	groupClient := getADGroupsClient()
+	return groupClient.Delete(ctx, groupObjID)
 }

--- a/graphrbac/graph_test.go
+++ b/graphrbac/graph_test.go
@@ -97,3 +97,25 @@ func ExampleCreateServicePrincipal() {
 	// list contributor roledefs at group scope
 	// assigned new principal to first contributor role
 }
+
+func ExampleCreateADGroup() {
+	ctx := context.Background()
+
+	group, err := CreateADGroup(ctx)
+	if err != nil {
+		util.PrintAndLog(err.Error())
+	}
+	util.PrintAndLog("ad group created")
+
+	if !config.KeepResources() {
+		_, err = DeleteADGroup(ctx, *group.ObjectID)
+		if err != nil {
+			util.PrintAndLog(err.Error())
+		}
+		util.PrintAndLog("ad group deleted")
+	}
+
+	// Output:
+	// ad group created
+	// ad group deleted if KeepResources=false
+}


### PR DESCRIPTION
Closes #186

This pull request aims to add an example of creating an Azure Active Directory group using the [azure-sdk-for-go graphrbac groups Create](https://github.com/Azure/azure-sdk-for-go/blob/6d20bdbae88c06c36d72eb512295417693bfdf4e/services/graphrbac/1.6/graphrbac/groups.go#L121) function. 

Any feedback on testing or formatting would be greatly appreciated.
