### PR TITLE
Fix insights sample

### DIFF
--- a/insights/insights.go
+++ b/insights/insights.go
@@ -50,7 +50,7 @@ func GetMetricsData(ctx context.Context, resourceID string, metrics []string) ([
 	startTime := endTime.Add(time.Duration(-5) * time.Minute)
 	timespan := fmt.Sprintf("%s/%s", startTime.Format(time.RFC3339), endTime.Format(time.RFC3339))
 
-	resp, err := metricsClient.List(context.Background(), resourceID, timespan, nil, strings.Join(metrics, ","), "", nil, "", "", insights.Data, "")
+	resp, err := metricsClient.List(context.Background(), resourceID, timespan, nil, strings.Join(metrics, ","), "minimum,maximum", nil, "", "", insights.Data, "")
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
The insights sample expected min/max values but didn't specify that in
the aggregation type.  As a result, querying some services that don't
use min/max as their primary aggregation type would always return zero
for these values.

Thanks for your contribution! Please let us know what problems this PR addresses or what functionality it adds. Please link to other related issues and PRs to speed up review. Thank you!
