### PR TITLE
Documentation: Include Information on dep in Main README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,13 +5,13 @@ azure-sdk-for-go-samples is a collection of sample usages of the
 
 [![Build Status](https://travis-ci.org/Azure-Samples/azure-sdk-for-go-samples.svg?branch=master)](https://travis-ci.org/Azure-Samples/azure-sdk-for-go-samples)
 
-For general SDK help, start with the [main SDK README][].
+For general SDK help, start with the [Main SDK README][].
 
 ## To run tests
 
 1. set up authentication (see following)
 1. `dep ensure`
-* For more information on `dep` for Go package dependency management, please read more here: [main SDK README][#Package Updates]
+* For more information on `dep` for Go package dependency management, please read more here: [Main SDK README](#package-updates)
 1. `go test -v ./network/` (or any package)
 
 To run all tests: `make test`.
@@ -56,7 +56,7 @@ This code is provided under the MIT license. See [LICENSE][] for details.
 
 We welcome your contributions! For instructions and our code of conduct see [CONTRIBUTING.md][]. And thank you!
 
-[main SDK README]: https://github.com/Azure/azure-sdk-for-go/blob/master/README.md
+[Main SDK README]: https://github.com/Azure/azure-sdk-for-go/blob/master/README.md
 [Azure update feed]: https://azure.microsoft.com/updates/
 [Azure/azure-sdk-for-go]: https://github.com/Azure/azure-sdk-for-go
 [azure-cli]: https://github.com/Azure/azure-cli

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ For general SDK help, start with the [main SDK README][].
 
 1. set up authentication (see following)
 1. `dep ensure`
-* For more information on `dep`, please read more [here](https://github.com/Azure/azure-sdk-for-go/blame/master/README.md#L41)
+* For more information on `dep` for Go package dependency management, please read more here: [main SDK README][#Package Updates]
 1. `go test -v ./network/` (or any package)
 
 To run all tests: `make test`.

--- a/README.md
+++ b/README.md
@@ -10,8 +10,7 @@ For general SDK help, start with the [Main SDK README][].
 ## To run tests
 
 1. set up authentication (see following)
-1. `dep ensure`
-* For more information on `dep` for Go package dependency management, please read more [here](https://github.com/Azure/azure-sdk-for-go/blob/master/README.md#package-updates).
+1. `dep ensure` (For more information on `dep` for Go package dependency management, please read more [here](https://github.com/Azure/azure-sdk-for-go/blob/master/README.md#package-updates).)
 1. `go test -v ./network/` (or any package)
 
 To run all tests: `make test`.

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ For general SDK help, start with the [main SDK README][].
 
 1. set up authentication (see following)
 1. `dep ensure`
+* For more information on `dep`, please read more [here](https://github.com/Azure/azure-sdk-for-go/blame/master/README.md#L41)
 1. `go test -v ./network/` (or any package)
 
 To run all tests: `make test`.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ For general SDK help, start with the [Main SDK README][].
 
 1. set up authentication (see following)
 1. `dep ensure`
-* For more information on `dep` for Go package dependency management, please read more here: [Main SDK README](#package-updates)
+* For more information on `dep` for Go package dependency management, please read more [here](https://github.com/Azure/azure-sdk-for-go/blob/master/README.md#package-updates).
 1. `go test -v ./network/` (or any package)
 
 To run all tests: `make test`.


### PR DESCRIPTION
Currently, the main README for `azure-sdk-for-go-samples` includes instructions on running tests that includes running `dep ensure`. I think it would be helpful to link the section of the `azure-sdk-for-go` README that details [Package Updates](https://github.com/Azure/azure-sdk-for-go/blob/master/README.md#package-updates) with the instruction for running this command. This will be helpful for any new Go developers who may be unfamiliar with `dep`. 

Considerations:
* I personally found it easier to use `go get -u github.com/Azure/azure-sdk-for-go` for installing dependencies than using `dep`. Seeing as this is a sample repo, it may be better to recommend using `go get -u github.com/Azure/azure-sdk-for-go` rather than `dep` so that users can get going quicker with actually running the samples. 