### PR TITLE
Add GetVirtualNetwork to network samples

### DIFF
--- a/network/network.go
+++ b/network/network.go
@@ -26,6 +26,12 @@ func getVnetClient() network.VirtualNetworksClient {
 	return vnetClient
 }
 
+// GetVirtualNetwork gets info on a virtual network
+func GetVirtualNetwork(ctx context.Context, vnetName string) (network.VirtualNetwork, error) {
+	vnetClient := getVnetClient()
+	return vnetClient.Get(ctx, config.GroupName(), vnetName, "")
+}
+
 // CreateVirtualNetwork creates a virtual network
 func CreateVirtualNetwork(ctx context.Context, vnetName string) (vnet network.VirtualNetwork, err error) {
 	vnetClient := getVnetClient()

--- a/network/network_test.go
+++ b/network/network_test.go
@@ -81,6 +81,12 @@ func TestNetwork(t *testing.T) {
 	}
 	t.Logf("created vnet with 2 subnets")
 
+	_, err = GetVirtualNetwork(ctx, virtualNetworkName)
+	if err != nil {
+		t.Fatalf("failed to get vnet: %v\n", err.Error())
+	}
+	t.Logf("got vnet %s\n", virtualNetworkName)
+
 	_, err = CreateNetworkSecurityGroup(ctx, nsgName)
 	if err != nil {
 		t.Fatalf("failed to create NSG: %v\n", err.Error())


### PR DESCRIPTION
Not sure if wanted, but have been working w/ VirtualNetwork objects and noticed the samples were lacking the get method. 