### PR TITLE
Fix links to docs site

### DIFF
--- a/quickstarts/deploy-vm/README.md
+++ b/quickstarts/deploy-vm/README.md
@@ -1,12 +1,12 @@
 # Azure SDK for Go quickstart: Creating a VM
 
-This code accompanies the Azure documentation quickstart [Deploy an Azure virtual machine with the Azure SDK for Go](http://docs.microsoft.com/go/azure/azure-sdk-go-qs-vm). Running this code will
+This code accompanies the Azure documentation quickstart [Deploy an Azure virtual machine with the Azure SDK for Go](http://docs.microsoft.com/azure/go/azure-sdk-go-qs-vm). Running this code will
 load up a provisioning file provided by the user (one is included) that deploys a full VM on Azure.
  
 This code compiles out of the box, but will not successfully complete. It requires you to change values to correctly authenticate with your own
 Azure account, and provide other configuration information.
 
-For more information and the most up-to-date instructions on configuring your Azure account and environment to run this quickstart code, please see our full [quickstart article](http://docs.microsoft.com/go/azure/azure-sdk-go-qs-vm), and [learn more about the Azure SDK for Go](http://docs.microsoft.com/go/azure).
+For more information and the most up-to-date instructions on configuring your Azure account and environment to run this quickstart code, please see our full [quickstart article](http://docs.microsoft.com/azure/go/azure-sdk-go-qs-vm), and [learn more about the Azure SDK for Go](http://docs.microsoft.com/azure/go).
 
 # License
 


### PR DESCRIPTION
This PR fixes links to the Azure docs site that may 404 after relocating the Go content.