### PR TITLE
fix storage and eventhubs tests

### DIFF
--- a/eventhubs/eventhubs_test.go
+++ b/eventhubs/eventhubs_test.go
@@ -19,8 +19,8 @@ import (
 )
 
 const (
-	nsName   = "ehtest-04-ns"
-	hubName  = "ehtest-04-hub"
+	nsName   = "ehtest04ns"
+	hubName  = "ehtest04hub"
 
 	// for storage.LeaserCheckpointer
 	storageAccountName   = "ehtest0001storage"

--- a/storage/account_test.go
+++ b/storage/account_test.go
@@ -86,11 +86,11 @@ func Example_storageAccountOperations() {
 	}
 	util.PrintAndLog("get storage account keys")
 
-	_, err = RegenerateAccountKey(ctx, accountName, groupName, 0)
+	_, err = RegenerateAccountKey(ctx, accountName, groupName, 1)
 	if err != nil {
 		util.LogAndPanic(err)
 	}
-	util.PrintAndLog("regenerated first storage account key")
+	util.PrintAndLog("regenerated second storage account key")
 
 	_, err = ListUsage(ctx)
 	if err != nil {
@@ -107,6 +107,6 @@ func Example_storageAccountOperations() {
 	// listed storage accounts in resource group
 	// listed storage accounts in subscription
 	// get storage account keys
-	// regenerated first storage account key
+	// regenerated second storage account key
 	// listed usage
 }

--- a/storage/pageblob.go
+++ b/storage/pageblob.go
@@ -57,7 +57,7 @@ func ClearPage(ctx context.Context, accountName, accountGroupName, containerName
 
 	_, err := b.ClearPages(ctx,
 		int64(pageNumber*azblob.PageBlobPageBytes),
-		int64((pageNumber+1)*azblob.PageBlobPageBytes-1),
+		int64(azblob.PageBlobPageBytes),
 		azblob.PageBlobAccessConditions{},
 	)
 	return err


### PR DESCRIPTION
Before this update: Tests for eventhubs and storage would fail (raise error).
After this update: Tests for eventhubs and storage passes (with expected results).
